### PR TITLE
Refactor Notion import to reuse database metadata

### DIFF
--- a/scripts/import_to_notion.mjs
+++ b/scripts/import_to_notion.mjs
@@ -2,14 +2,73 @@ import fs from "fs/promises";
 import path from "path";
 import matter from "gray-matter";
 import { Client } from "@notionhq/client";
+import { fileURLToPath } from "url";
 
 const notion = new Client({ auth: process.env.NOTION_TOKEN });
 const DB = process.env.NOTION_DB_ARTICLES;
-const BLOG_DIR = path.resolve(path.dirname(new URL(import.meta.url).pathname), "../content/blog");
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const BLOG_DIR = path.resolve(__dirname, "../content/blog");
 
 function chunk(t, sz=1800){ const a=[]; for(let i=0;i<t.length;i+=sz) a.push(t.slice(i,i+sz)); return a; }
 
-async function upsert(fm, md){
+function nonEmpty(v) {
+  if (v == null) return false;
+  if (typeof v === "string") return v.trim() !== "";
+  if (Array.isArray(v)) return v.length > 0;
+  if (typeof v === "object") return Object.keys(v).length > 0;
+  return true;
+}
+
+export async function getDbMeta() {
+  const meta = await notion.databases.retrieve({ database_id: DB });
+  const titleEntry = Object.entries(meta.properties).find(([, v]) => v?.type === "title");
+  const TITLE_KEY = titleEntry ? titleEntry[0] : "Name";
+  const statusProp = meta.properties["Status"];
+  const statusType = statusProp?.type;
+  return { TITLE_KEY, statusType };
+}
+
+export function buildProps(fm, meta) {
+  const { TITLE_KEY, statusType } = meta;
+  const props = {};
+
+  // title
+  props[TITLE_KEY] = { title: [{ text: { content: fm.title || fm.slug || "Untitled" } }] };
+
+  // Slug
+  if (nonEmpty(fm.slug)) props["Slug"] = { rich_text: [{ text: { content: fm.slug } }] };
+
+  // Status
+  if (nonEmpty(fm.status)) {
+    if (statusType === "status") {
+      props["Status"] = { status: { name: fm.status } };
+    } else if (statusType === "select") {
+      props["Status"] = { select: { name: fm.status } };
+    }
+  }
+
+  // Publish
+  if (nonEmpty(fm.publish_date)) props["Publish"] = { date: { start: fm.publish_date } };
+
+  // Tags
+  const tags = Array.isArray(fm.tags) ? fm.tags.map(t => ({ name: String(t) })) : [];
+  props["Tags"] = { multi_select: tags };
+
+  // SEO fields
+  const seoTitle = fm?.seo?.title || "";
+  const seoDesc  = fm?.seo?.description || "";
+  if (nonEmpty(seoTitle)) props["SEO_Title"] = { rich_text: [{ text: { content: seoTitle } }] };
+  if (nonEmpty(seoDesc))  props["SEO_Description"] = { rich_text: [{ text: { content: seoDesc } }] };
+
+  // ShopifyArticleID
+  const sid = fm?.ids?.shopify_article_id || "";
+  if (nonEmpty(sid)) props["ShopifyArticleID"] = { rich_text: [{ text: { content: sid } }] };
+
+  return props;
+}
+
+export async function upsert(fm, md, meta){
   let page=null;
   if(fm?.ids?.shopify_article_id){
     const q=await notion.databases.query({
@@ -18,72 +77,8 @@ async function upsert(fm, md){
     });
     page=q.results?.[0]||null;
   }
-  // ===== [CURSOR INSERT A] DB metadata & helpers: BEGIN =====
-  // --- DB metadata & helpers ---
-  const meta = await notion.databases.retrieve({ database_id: DB });
-  // real title key
-  const titleEntry = Object.entries(meta.properties).find(([, v]) => v?.type === "title");
-  const TITLE_KEY = titleEntry ? titleEntry[0] : "Name"; // fallback
-  // Status type detection
-  const statusProp = meta.properties["Status"];
-  const isStatusType = statusProp?.type === "status"; // new type
-  const isSelectType = statusProp?.type === "select"; // legacy type
 
-  function nonEmpty(v) {
-    if (v == null) return false;
-    if (typeof v === "string") return v.trim() !== "";
-    if (Array.isArray(v)) return v.length > 0;
-    if (typeof v === "object") return Object.keys(v).length > 0;
-    return true;
-  }
-
-  function buildProps(fm) {
-    const props = {};
-
-    // title
-    props[TITLE_KEY] = { title: [{ text: { content: fm.title || fm.slug || "Untitled" } }] };
-
-    // Slug
-    if (nonEmpty(fm.slug)) props["Slug"] = { rich_text: [{ text: { content: fm.slug } }] };
-
-    // Status
-    if (nonEmpty(fm.status)) {
-      if (isStatusType) {
-        props["Status"] = { status: { name: fm.status } };
-      } else if (isSelectType) {
-        props["Status"] = { select: { name: fm.status } };
-      }
-    }
-
-    // Publish
-    if (nonEmpty(fm.publish_date)) props["Publish"] = { date: { start: fm.publish_date } };
-
-    // Tags
-    const tags = Array.isArray(fm.tags) ? fm.tags.map(t => ({ name: String(t) })) : [];
-    props["Tags"] = { multi_select: tags };
-
-    // SEO fields
-    const seoTitle = fm?.seo?.title || "";
-    const seoDesc  = fm?.seo?.description || "";
-    if (nonEmpty(seoTitle)) props["SEO_Title"] = { rich_text: [{ text: { content: seoTitle } }] };
-    if (nonEmpty(seoDesc))  props["SEO_Description"] = { rich_text: [{ text: { content: seoDesc } }] };
-
-    // ShopifyArticleID
-    const sid = fm?.ids?.shopify_article_id || "";
-    if (nonEmpty(sid)) props["ShopifyArticleID"] = { rich_text: [{ text: { content: sid } }] };
-
-    return props;
-  }
-  // ===== [CURSOR INSERT A] DB metadata & helpers: END =====
-
-  // ===== [CURSOR INSERT B] Build props and use: BEGIN =====
-  const props = buildProps(fm);
-  // DEBUG (optional):
-  // console.log("[DBG] TITLE_KEY =", TITLE_KEY);
-  // console.log("[DBG] PROPS_KEYS =", Object.keys(props));
-  // console.log("[DBG] PROPS.Name =", JSON.stringify(props.Name));
-  // ===== [CURSOR INSERT B] Build props and use: END =====
-
+  const props = buildProps(fm, meta);
   const blocks=[{ object:"block", type:"code", code:{ language:"markdown", rich_text: chunk(md).map(s=>({type:"text",text:{content:s}})) } }];
 
   if(!page){
@@ -99,13 +94,17 @@ async function upsert(fm, md){
 async function run(){
   if(!process.env.NOTION_TOKEN||!DB) throw new Error("Missing NOTION_TOKEN or NOTION_DB_ARTICLES");
   const files=(await fs.readdir(BLOG_DIR)).filter(f=>f.endsWith(".md"));
+  const meta = await getDbMeta();
   let ok=0;
   for(const f of files){
     const raw=await fs.readFile(path.join(BLOG_DIR,f),"utf8");
     const { data: fm, content: md } = matter(raw);
-    const id=await upsert(fm, md);
+    const id=await upsert(fm, md, meta);
     console.log(`Notion upsert: ${fm.title} -> ${id}`); ok++;
   }
   console.log(`Done: ${ok} page(s)`);
 }
-run().catch(e=>{ console.error(e); process.exit(1); });
+
+if (process.argv[1] === __filename) {
+  run().catch(e=>{ console.error(e); process.exit(1); });
+}


### PR DESCRIPTION
## Summary
- compute Notion database metadata once via `getDbMeta`
- make `buildProps` and `upsert` accept metadata instead of fetching inside
- call `getDbMeta` before import loop and pass metadata to `upsert`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node scripts/import_to_notion.mjs` *(fails: Missing NOTION_TOKEN or NOTION_DB_ARTICLES)*

------
https://chatgpt.com/codex/tasks/task_e_68a72b4db29083248bfdecc00936eb25