### PR TITLE
Add example environment configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# Example environment configuration for shopify-content-sync
+
+# Shopify API credentials
+SHOPIFY_STORE=your-shopify-store.myshopify.com
+SHOPIFY_ADMIN_TOKEN=your-shopify-admin-token
+
+# Notion API credentials
+NOTION_TOKEN=your-notion-integration-token
+NOTION_DB_ARTICLES=your-notion-database-id
+
+# Optional settings
+# No optional environment variables are defined; scripts use built-in defaults.


### PR DESCRIPTION
## Summary
- Provide `.env.example` with placeholders for Shopify store, Shopify admin token, Notion token, and Notion articles database ID
- Note that no optional environment variables are currently defined

## Testing
- `npm test` *(fails: missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a72b4ff2ac83248eac57cce33c675a